### PR TITLE
Create GRumble2026 update

### DIFF
--- a/tournament-app/functions/package-lock.json
+++ b/tournament-app/functions/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2176,6 +2177,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -2638,6 +2640,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3189,6 +3192,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4058,6 +4062,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4749,6 +4754,7 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
       "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "1.0.8",
@@ -4773,6 +4779,7 @@
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.4.0.tgz",
       "integrity": "sha512-Q/LGhJrmJEhT0dbV60J4hCkVSeOM6/r7xJS/ccmkXzTWMjo+UPAYX9zlQmGlEjotstZ0U9GtQSJSgbB2Z+TJDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "^4.17.21",
@@ -6230,6 +6237,7 @@
       "integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.5",
         "@jest/types": "30.0.5",
@@ -9469,6 +9477,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/tournament-app/functions/src/index.ts
+++ b/tournament-app/functions/src/index.ts
@@ -113,28 +113,57 @@ export const getAuthTokenForAccessCode = https.onCall<AuthData>(
       );
     }
 
-    // Query the secure collection for a matching access code
-    const codesRef = db.collection("teamAccessCodes");
-    const snapshot = await codesRef
-      .where("accessCode", "==", accessCode)
-      .limit(1)
-      .get();
+    const year = (rawRequest.data as any).year || "2026";
+    const prefix = `grumble${year}`;
 
-    if (snapshot.empty) {
+    const masterRef = db.collection("teamAccessCodes").doc(`${prefix}_master`);
+    const goldRef = db.collection("teamAccessCodes").doc(`${prefix}_gold`);
+
+    const [masterSnap, goldSnap] = await Promise.all([
+      masterRef.get(),
+      goldRef.get(),
+    ]);
+
+    let matchedData: any = null;
+    let matchedId: string | null = null;
+
+    if (masterSnap.exists) {
+      const data = masterSnap.data();
+      for (const [id, entry] of Object.entries(data || {})) {
+        if ((entry as any).accessCode === accessCode) {
+          matchedData = entry;
+          matchedId = id;
+          break;
+        }
+      }
+    }
+
+    if (!matchedData && goldSnap.exists) {
+      const data = goldSnap.data();
+      for (const [id, entry] of Object.entries(data || {})) {
+        if ((entry as any).accessCode === accessCode) {
+          matchedData = entry;
+          matchedId = id;
+          break;
+        }
+      }
+    }
+
+    if (!matchedData) {
       throw new https.HttpsError(
         "not-found",
         "Invalid access code."
       );
     }
-    logger.debug(
-      `Access granted to ${snapshot.docs[0].data().captainName}`);
+
+    logger.debug(`Access granted to ${matchedData.captainName}`);
 
     // Get the teamId from the matched document"s ID
-    const isLegacyTeamId = !Number.isNaN(Number(snapshot.docs[0].id));
+    const isLegacyTeamId = !Number.isNaN(Number(matchedId));
     const teamId = isLegacyTeamId ?
-      Number(snapshot.docs[0].id) :
-      snapshot.docs[0].data().teamId;
-    const division = snapshot.docs[0].data().division ?? "";
+      Number(matchedId) :
+      matchedData.teamId;
+    const division = matchedData.division ?? "";
     logger.debug(`Team access for division ${division}`);
     const uid = `captain-${teamId}`; // Create a unique ID for this user
 

--- a/tournament-app/package.json
+++ b/tournament-app/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -b deploy -d build",
-    "start": "react-scripts start",
-    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
+    "start": "NODE_OPTIONS=\"--require ./suppress-localstorage.js\" react-scripts start",
+    "build": "NODE_OPTIONS=\"--require ./suppress-localstorage.js\" DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/tournament-app/src/AppContent.tsx
+++ b/tournament-app/src/AppContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 
 
@@ -24,13 +24,26 @@ import { useGameMatches } from './context/MatchesContext';
 import MatchResultPage from './components/MatchResult/MatchResultPage';
 import TeamKnockoutPage from './components/TeamPage/TeamKnockoutPage';
 import PlayerProfilePage from './components/Players/PlayerProfilePage';
+import { getYearFromHash } from './utils';
 
 const AppContent: React.FC = () => {
   const { currentUser: user } = useAuth();
   const { matches } = useGameMatches();
+  
+  const [hash, setHash] = useState(window.location.hash);
+  
+  useEffect(() => {
+    const handleHashChange = () => setHash(window.location.hash);
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  const year = getYearFromHash(hash) || '2026';
+  const basename = getYearFromHash(hash) ? `/${getYearFromHash(hash)}` : undefined;
+  const is2026 = year === '2026';
 
   return (
-    <Router>
+    <Router basename={basename}>
       <RouteChangeTracker />
       <AppContainer>
           <Header />
@@ -38,8 +51,8 @@ const AppContent: React.FC = () => {
             <Routes>
                 <Route 
                 path="/" 
-                element={<Tournament />} 
-                />
+                  element={<Tournament />} 
+                  />
                 <Route path="/schedule" element={<SchedulePage />} />
                 <Route 
                 path="/swiss" 

--- a/tournament-app/src/components/Admin/AdminPage.tsx
+++ b/tournament-app/src/components/Admin/AdminPage.tsx
@@ -9,6 +9,7 @@ import { AdminPageContainer, AdminTitle, Form, TextArea, SelectionContainer, For
 import { useDivision } from '../../context/DivisionContext';
 import { z } from 'zod';
 import { useAuth } from '../Common/AuthContext';
+import { getFirebasePrefix } from '../../utils';
 
 const StatusMessage = styled.p<{ status: 'success' | 'error' }>` /* ... same as other pages ... */ `;
 const JsonOutput = styled.pre`
@@ -212,7 +213,8 @@ const AdminPage: React.FC = () => {
         setCopied(false);
 
         try {
-            const docRef = doc(db, 'drafts', 'grumble2025_master');
+            const prefix = getFirebasePrefix();
+            const docRef = doc(db, 'drafts', `${prefix}_master`);
             const docSnap = await getDoc(docRef);
 
             if (docSnap.exists()) {
@@ -226,7 +228,8 @@ const AdminPage: React.FC = () => {
                     throw new Error("'teams' field is missing or not an array in the document.");
                 }
             } else {
-                throw new Error("Document 'drafts/grumble2025_master' not found.");
+                const prefix = getFirebasePrefix();
+                throw new Error(`Document 'drafts/${prefix}_master' not found.`);
             }
         } catch (error) {
             console.error("Error fetching teams data:", error);
@@ -311,7 +314,8 @@ const AdminPage: React.FC = () => {
 
                 await batch.commit();
             } else {
-                const docRef = doc(db, selectedType === 'subs' ? 'players' : selectedType, `grumble2025_${division}`);
+                const prefix = getFirebasePrefix();
+                const docRef = doc(db, selectedType === 'subs' ? 'players' : selectedType, `${prefix}_${division}`);
                 await updateDoc(docRef, {
                     [selectedType]: arrayUnion(...data)
                 });
@@ -391,7 +395,7 @@ const AdminPage: React.FC = () => {
                 return (
                 <div>
                     <h3>Export Team Rosters from Draft</h3>
-                    <p>Click the button below to fetch the `teams` field from the `drafts/grumble2025_test` document and display it as JSON.</p>
+                    <p>Click the button below to fetch the `teams` field from the `drafts/${getFirebasePrefix()}_test` document and display it as JSON.</p>
                     <ActionContainer>
                     <Button onClick={handleFetchTeams} disabled={exportStatus === 'loading'}>
                         {exportStatus === 'loading' ? 'Fetching...' : 'Fetch and Print Teams'}

--- a/tournament-app/src/components/Common/Header.tsx
+++ b/tournament-app/src/components/Common/Header.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { getAuth, User } from 'firebase/auth';
-import {  HamburgerIcon, MobileMenu, HeaderLeft, HeaderContainer, Logo, MobileMainLink, MobileNavItem, MobileSubMenu, MobileSubMenuItem, Nav, NavItem, SubMenu, SubMenuItem } from '../../styles';
+import { HamburgerIcon, MobileMenu, HeaderLeft, HeaderContainer, Logo, MobileMainLink, MobileNavItem, MobileSubMenu, MobileSubMenuItem, Nav, NavItem, SubMenu, SubMenuItem, SubMenuAction, MobileSubMenuAction } from '../../styles';
 import { FaBars, FaChevronDown, FaTimes } from 'react-icons/fa';
 import DivisionSelector from './DivisionSelector';
 import ThemeToggleButton from './ThemeToggleButton';
+import { getYearDisplayString } from '../../utils';
 
 const Header: React.FC = () => {
   const auth = getAuth();
@@ -27,15 +28,19 @@ const Header: React.FC = () => {
   }
 
   // Listen to auth state to show/hide the captain link
+  const [hash, setHash] = useState(window.location.hash);
   useEffect(() => {
-    const unsubscribe = auth.onAuthStateChanged(setUser);
-    return () => unsubscribe();
-  }, [auth]);
+    const handleHashChange = () => setHash(window.location.hash);
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  const logoText = getYearDisplayString(hash);
 
   return (
     <HeaderContainer>
       <HeaderLeft>
-        <Logo to="/" onClick={closeAllMenus}>GRumble 2025</Logo>
+        <Logo to="/" onClick={closeAllMenus}>{logoText}</Logo>
         <DivisionSelector />
       </HeaderLeft>
       
@@ -66,6 +71,27 @@ const Header: React.FC = () => {
               <SubMenuItem to="/draft-access">Draft</SubMenuItem>
               {user && (<SubMenuItem to="/pick-priority">Auto-Draft</SubMenuItem>)}
               <SubMenuItem to="/subs">Substitutes</SubMenuItem>
+            </SubMenu>
+          </NavItem>
+
+          <NavItem>
+            Year <FaChevronDown size={12} />
+            <SubMenu>
+              <SubMenuAction
+                onClick={() => {
+                  const path = window.location.hash.replace(/^#\/2025/, '').replace(/^#/, '');
+                  window.location.hash = `#/2025`;
+                }}
+              >
+                Grumble 2025
+              </SubMenuAction>
+              <SubMenuAction
+                onClick={() => {
+                  window.location.hash = `#/2026`;
+                }}
+              >
+                Grumble 2026
+              </SubMenuAction>
             </SubMenu>
           </NavItem>
         </Nav>
@@ -106,6 +132,31 @@ const Header: React.FC = () => {
             <MobileSubMenuItem to="/draft-access" onClick={closeAllMenus}>Draft</MobileSubMenuItem>
             {user && (<MobileSubMenuItem to="/pick-priority" onClick={closeAllMenus}>Auto-Draft</MobileSubMenuItem>)}
             <MobileSubMenuItem to="/subs" onClick={closeAllMenus}>Substitutes</MobileSubMenuItem>
+          </MobileSubMenu>
+        </MobileNavItem>
+
+        <MobileNavItem>
+          <MobileMainLink onClick={() => toggleMobileSubMenu('year')}>
+            Year <FaChevronDown size={16} />
+          </MobileMainLink>
+          <MobileSubMenu isOpen={openMobileSubMenu === 'year'}>
+            <MobileSubMenuAction
+              onClick={() => {
+                const path = window.location.hash.replace(/^#\/2025/, '').replace(/^#/, '');
+                window.location.hash = `#/2025${path}`;
+                closeAllMenus();
+              }}
+            >
+              Grumble 2025
+            </MobileSubMenuAction>
+            <MobileSubMenuAction
+              onClick={() => {
+                window.location.hash = `#/2026`;
+                closeAllMenus();
+              }}
+            >
+              Grumble 2026
+            </MobileSubMenuAction>
           </MobileSubMenu>
         </MobileNavItem>
       </MobileMenu>

--- a/tournament-app/src/components/Draft/DraftAuthGate.tsx
+++ b/tournament-app/src/components/Draft/DraftAuthGate.tsx
@@ -5,6 +5,7 @@ import { getFunctions, httpsCallable } from 'firebase/functions';
 import Button from '../Common/Button';
 import { GateContainer, AuthBox, Input, ErrorMessage } from '../../styles';
 import { useAuth } from '../Common/AuthContext';
+import { getYearFromHash } from '../../utils';
 
 const DraftAuthGate: React.FC = () => {
   const navigate = useNavigate();
@@ -22,7 +23,8 @@ const DraftAuthGate: React.FC = () => {
     try {
       const functions = getFunctions();
       const getToken = httpsCallable(functions, 'getAuthTokenForAccessCode');
-      const result = await getToken({ accessCode });
+      const year = getYearFromHash(window.location.hash) || '2026';
+      const result = await getToken({ accessCode, year });
       const token = (result.data as { token: string }).token;
       
       await signInWithCustomToken(auth, token);

--- a/tournament-app/src/components/Draft/DraftPage.tsx
+++ b/tournament-app/src/components/Draft/DraftPage.tsx
@@ -10,7 +10,7 @@ import { DraftPageContainer, DraftHeader, Title, DraftStatus, DraftContent, Team
 import { usePlayers } from '../../context/PlayerContext';
 import { useAuth } from '../Common/AuthContext';
 import { useDivision } from '../../context/DivisionContext';
-import { compareRanks, createOpGgUrl, rankTierToShortName } from '../../utils';
+import { compareRanks, createOpGgUrl, rankTierToShortName, getFirebasePrefix } from '../../utils';
 import { ceil } from 'lodash';
 
 const DRAFT_PICK_TIME_LIMIT_IN_MS = 2 * 60 * 60 * 1000;
@@ -107,7 +107,8 @@ const initializeDraft = (allPlayers: Player[], division: string): DraftState => 
     currentPickIndex++;
   }
 
-  return { teams, pickOrder, availablePlayers, completedPicks: {}, currentPickIndex, draftId: `grumble2025_${division ?? "master"}` };
+  const prefix = getFirebasePrefix();
+  return { teams, pickOrder, availablePlayers, completedPicks: {}, currentPickIndex, draftId: `${prefix}_${division ?? "master"}` };
 };
 
 const emptyDraftState = (): DraftState => {
@@ -130,10 +131,17 @@ const DraftPage: React.FC = () => {
   const initialDraftState = initializeDraft(allPlayers, division);
   const { teams, pickOrder } = initialDraftState;
 
+  const [hash, setHash] = useState(window.location.hash);
+  useEffect(() => {
+    const handleHashChange = () => setHash(window.location.hash);
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  const prefix = getFirebasePrefix();
   const [draftState, setDraftState] = useState<DraftState>(emptyDraftState);
-  const [draftDocRef, setDraftDocRef] = useState(doc(db, 'drafts', `grumble2025_${division}`));
+  const [draftDocRef, setDraftDocRef] = useState(doc(db, 'drafts', `${prefix}_${division}`));
   const [loadingAuth, setLoadingAuth] = useState(true);
-  const [prevDivision, setPrevDivision] = useState('');
   const [isSpectator, setIsSpectator] = useState(sessionStorage.getItem('isSpectator') === 'true');
   const [isLoading, setIsLoading] = useState(true);
 
@@ -153,11 +161,10 @@ const DraftPage: React.FC = () => {
   //// END AUTH ////
 
   useEffect(() => {
-    if (division !== prevDivision) {
-      setDraftDocRef(doc(db, 'drafts', `grumble2025_${division}`));
-      setPrevDivision(division);
-    }
+    setDraftDocRef(doc(db, 'drafts', `${prefix}_${division}`));
+  }, [division, prefix]);
 
+  useEffect(() => {
     async function maybeInitData() {
       // Draft hasn't been initialized yet, update with initialize draft state
       const currentData = await getDoc(draftDocRef);
@@ -188,7 +195,7 @@ const DraftPage: React.FC = () => {
 
     // Clean up the listener when the component unmounts
     return () => unsubscribe();
-  }, [allPlayers, isAdmin, isSpectator, division, draftDocRef, draftState, draftState.currentPickIndex, draftState.draftId, prevDivision, setDraftDocRef, setPrevDivision]);
+  }, [allPlayers, isAdmin, isSpectator, division, draftDocRef, draftState, draftState.currentPickIndex, draftState.draftId, setDraftDocRef]);
 
   const handleDraftPlayer = useCallback(async (player: Player) => {
     if (!draftState) return;

--- a/tournament-app/src/components/Players/PlayerProfilePage.tsx
+++ b/tournament-app/src/components/Players/PlayerProfilePage.tsx
@@ -11,7 +11,7 @@ import { useTournament } from '../../context/TournamentContext';
 
 // --- TYPES & UTILS ---
 import { Player, Team, Match, MatchResultData, BracketSeed, BracketRound } from '../../types';
-import { createOpGgUrl } from '../../utils';
+import { createOpGgUrl, getFirebasePrefix } from '../../utils';
 import { MatchInfo, MatchResult, ResultIndicator, Score } from '../../styles';
 
 // --- STYLED COMPONENTS ---
@@ -170,8 +170,9 @@ const PlayerProfilePage: React.FC = () => {
       setPlayerTeam(team);
 
       // 3. Fetch all matches (Swiss and Knockout)
-      const swissMatchesDocRef = doc(db, 'matches', `grumble2025_${division}`);
-      const knockoutMatchesColRef = doc(db, 'bracket', `grumble2025_${division}`);
+      const prefix = getFirebasePrefix();
+      const swissMatchesDocRef = doc(db, 'matches', `${prefix}_${division}`);
+      const knockoutMatchesColRef = doc(db, 'bracket', `${prefix}_${division}`);
       
       const [swissSnap, knockoutSnap] = await Promise.all([
         getDoc(swissMatchesDocRef),

--- a/tournament-app/src/components/Players/SubstitutePlayersPage.tsx
+++ b/tournament-app/src/components/Players/SubstitutePlayersPage.tsx
@@ -4,7 +4,7 @@ import { db } from '../../firebase';
 import { SubPlayer } from '../../types';
 import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa'; 
 import { ControlsContainer, FilterGroup, SubsTableHead, ContactInfo, LoadingText, ErrorText, SubsPageContainer, SubsTitle, SubsPlayerTable, SubsLabel, SubsSelect, SubsTableBody, SubsCopyButton } from '../../styles/index';
-import { convertRankToElo } from '../../utils';
+import { convertRankToElo, getFirebasePrefix } from '../../utils';
 import { useDivision } from '../../context/DivisionContext';
 
 type SortDirection = 'ascending' | 'descending';
@@ -32,7 +32,8 @@ const SubstitutesPage: React.FC = () => {
       setError(null);
       
       try {
-        const docRef = doc(db, 'players', `grumble2025_${division}`);
+        const prefix = getFirebasePrefix();
+        const docRef = doc(db, 'players', `${prefix}_${division}`);
         const docSnap = await getDoc(docRef);
 
         if (docSnap.exists()) {

--- a/tournament-app/src/components/Schedule/SchedulePage.tsx
+++ b/tournament-app/src/components/Schedule/SchedulePage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FaCalendarAlt } from 'react-icons/fa';
 import { SchedulePageContainer, ScheduleTitle, TimelineContainer, StageCard, StageIcon, StageContent, StageTitle, StageDescription, StageLink, StageDate } from '../../styles';
 import { useDivision } from '../../context/DivisionContext';
+import { getYearFromHash } from '../../utils';
 
 const tournamentStagesMaster = [
   {
@@ -90,13 +91,17 @@ const tournamentStagesGold = [
 
 const SchedulePage: React.FC = () => {
   const { division } = useDivision();
+  const year = getYearFromHash(window.location.hash) || '2026';
+  const is2026 = year === '2026';
 
   const getIconContent = (startDate: Date, endDate: Date, number: number) => {
+    if (is2026) return number;
     if (getStatusFromDate(startDate, endDate) === 'completed') return '✓';
     return number;
   }
 
   const getStatusFromDate = (startDate: Date, endDate: Date) => {
+    if (is2026) return "upcoming";
     const now = Date.now()
     if (now >= endDate.getTime()) return "completed";
     if (now >= startDate.getTime() && now <= endDate.getTime()) {
@@ -120,7 +125,7 @@ const SchedulePage: React.FC = () => {
               <StageTitle>{stage.title}</StageTitle>
               <StageDate>
                 <FaCalendarAlt />
-                <span>{stage.date?.toDateString()}</span>
+                <span>{is2026 ? "TBD" : stage.date?.toDateString()}</span>
               </StageDate>
               <StageDescription>{stage.description}</StageDescription>
               {stage.link && (

--- a/tournament-app/src/components/Tournament.tsx
+++ b/tournament-app/src/components/Tournament.tsx
@@ -13,7 +13,7 @@ const Tournament: React.FC = () => {
     const checkStreamTime = () => {
       // 1. Get the current time's timestamp
       const now = Date.now();
-      
+
       // 2. Create a Date object from our specific timezone string
       // This will be correctly interpreted by all modern browsers.
       const startTime = new Date(STREAM_START_ISO_WITH_OFFSET);
@@ -23,7 +23,7 @@ const Tournament: React.FC = () => {
 
       // 4. Compare the timestamps
       const isLive = now >= startTimeMillis;
-      
+
       setIsStreamLive(isLive);
       console.log(`Time check: Stream is currently ${isLive ? 'LIVE' : 'OFFLINE'}.`);
     };
@@ -40,13 +40,6 @@ const Tournament: React.FC = () => {
 
   return (
     <TournamentContainer>
-      <div>
-        <SectionTitle>Master Finals - October 26th 3pm PT / 6pm ET</SectionTitle>
-        {isStreamLive ? (
-          <TwitchEmbed channel="grumbleofficial" />
-        ) : <></>}
-
-      </div>
       <div>
         <SectionTitle>Swiss Stage</SectionTitle>
         <SwissStage />

--- a/tournament-app/src/context/MatchesContext.tsx
+++ b/tournament-app/src/context/MatchesContext.tsx
@@ -3,6 +3,7 @@ import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firesto
 import { db } from '../firebase';
 import { Match, TournamentCode } from '../types';
 import { useDivision } from './DivisionContext';
+import { getFirebasePrefix } from '../utils';
 
 // Define the shape of the data the context will provide
 interface MatchesContextType {
@@ -16,6 +17,13 @@ const MatchesContext = createContext<MatchesContextType | undefined>(undefined);
 
 // Create the Provider component
 export const MatchProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+    const [hash, setHash] = useState(window.location.hash);
+    useEffect(() => {
+        const handleHashChange = () => setHash(window.location.hash);
+        window.addEventListener('hashchange', handleHashChange);
+        return () => window.removeEventListener('hashchange', handleHashChange);
+    }, []);
+
     const [matches, setMatches] = useState<Match[]>([]);
     const [tournamentCodes, setTournamentCodes] = useState<TournamentCode[]>([]);
     const [loading, setLoading] = useState(true);
@@ -27,11 +35,14 @@ export const MatchProvider: React.FC<{ children: ReactNode }> = ({ children }) =
         const fetchMatches = async () => {
             setLoading(true);
             try {
-                const matchesRef = doc(db, 'matches', `grumble2025_${division}`)
+                const prefix = getFirebasePrefix();
+                const matchesRef = doc(db, 'matches', `${prefix}_${division}`)
                 const snapshot = await getDoc(matchesRef);
 
                 if (snapshot.exists()) {
                     setMatches(snapshot.data().matches);
+                } else {
+                    setMatches([]);
                 }
             } catch (error) {
                 console.error("Failed to fetch player data:", error);
@@ -66,7 +77,7 @@ export const MatchProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
         fetchMatches();
         fetchTournamentCodes();
-    }, [division]);
+    }, [division, hash]);
 
 
   const value = {

--- a/tournament-app/src/context/PlayerContext.tsx
+++ b/tournament-app/src/context/PlayerContext.tsx
@@ -3,6 +3,7 @@ import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { Player } from '../types';
 import { useDivision } from './DivisionContext';
+import { getFirebasePrefix } from '../utils';
 
 // Define the shape of the data the context will provide
 interface PlayerContextType {
@@ -17,6 +18,13 @@ const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 
 // Create the Provider component
 export const PlayerProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [hash, setHash] = useState(window.location.hash);
+  useEffect(() => {
+    const handleHashChange = () => setHash(window.location.hash);
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
   const [players, setPlayers] = useState<Player[]>([]);
   const [draftablePlayers, setDraftablePlayers] = useState<Player[]>([]);
   const [loading, setLoading] = useState(true);
@@ -28,11 +36,14 @@ export const PlayerProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     const fetchPlayers = async () => {
       setLoading(true);
       try {
-        const playersRef = doc(db, 'players', `grumble2025_${division}`);
+        const prefix = getFirebasePrefix();
+        const playersRef = doc(db, 'players', `${prefix}_${division}`);
         const snapshot = await getDoc(playersRef);
 
         if (snapshot.exists()) {
             setPlayers(snapshot.data().players);
+        } else {
+            setPlayers([]);
         }
       } catch (error) {
         console.error("Failed to fetch player data:", error);
@@ -45,11 +56,14 @@ export const PlayerProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       setLoading(true);
 
       try {
-        const draftRef = doc(db, 'drafts', `grumble2025_${division}`);
+        const prefix = getFirebasePrefix();
+        const draftRef = doc(db, 'drafts', `${prefix}_${division}`);
         const snapshot = await getDoc(draftRef);
 
         if (snapshot.exists()) {
           setDraftablePlayers(snapshot.data().availablePlayers);
+        } else {
+          setDraftablePlayers([]);
         }
       } catch (error) {
         console.error("Failed to fetch draft data:", error);
@@ -60,7 +74,7 @@ export const PlayerProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
     fetchPlayers();
     fetchRemainingDraftablePlayers();
-  }, [division]);
+  }, [division, hash]);
 
   // Helper function to find a player by ID, memoized for performance
   const getPlayerById = (id: number) => players.find(p => p.id === id);

--- a/tournament-app/src/context/TournamentContext.tsx
+++ b/tournament-app/src/context/TournamentContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useEffect, useContext, ReactNode } from
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useDivision } from './DivisionContext';
+import { getFirebasePrefix } from '../utils';
 import { Team, Group, BracketRound, Player } from '../types';
 
 // Define the shape of the data the context will provide
@@ -13,9 +14,16 @@ interface TournamentContextType {
 }
 
 const TournamentContext = createContext<TournamentContextType | undefined>(undefined);
-const GRUMBLE_YEAR_PREFIX = "grumble2025";
 
 export const TournamentProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [hash, setHash] = useState(window.location.hash);
+  useEffect(() => {
+    const handleHashChange = () => setHash(window.location.hash);
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  const GRUMBLE_YEAR_PREFIX = getFirebasePrefix();
   const { division } = useDivision(); 
   const [players, setPlayers] = useState<Player[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
@@ -23,7 +31,7 @@ export const TournamentProvider: React.FC<{ children: ReactNode }> = ({ children
   const [bracket, setBracket] = useState<BracketRound[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // This effect will run whenever the component mounts OR whenever the `division` changes
+  // This effect will run whenever the component mounts OR whenever the `division` or year prefix changes
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -45,18 +53,26 @@ export const TournamentProvider: React.FC<{ children: ReactNode }> = ({ children
         if (playersSnap.exists()) {
             const playersData = playersSnap.data();
             setPlayers(playersData.players);
+        } else {
+            setPlayers([]);
         }
         if (teamsSnap.exists()) {
             const teamsData = teamsSnap.data()
             setTeams(teamsData.teams);
+        } else {
+            setTeams([]);
         }
         if (groupsSnap.exists()) {
             const groupsData = groupsSnap.data();
             setGroups(groupsData.groups);
+        } else {
+            setGroups([]);
         }
         if (bracketSnap.exists()) {
             const bracketData = bracketSnap.data();
             setBracket(bracketData.bracket);
+        } else {
+            setBracket([]);
         }
 
 
@@ -72,7 +88,7 @@ export const TournamentProvider: React.FC<{ children: ReactNode }> = ({ children
     };
 
     fetchData();
-  }, [division]); 
+  }, [division, GRUMBLE_YEAR_PREFIX]); 
 
   const value = { players, teams, groups, bracket, loading };
 

--- a/tournament-app/src/styles/index.ts
+++ b/tournament-app/src/styles/index.ts
@@ -165,6 +165,18 @@ export const SubMenuItem = styled(RouterNavLink)`
   }
 `;
 
+export const SubMenuAction = styled.div`
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  color: ${({ theme }) => theme.text};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.body};
+  }
+`;
+
 export const MobileNavItem = styled.div`
   width: 100%;
 `;
@@ -200,6 +212,18 @@ export const MobileSubMenuItem = styled(RouterNavLink)`
   &.active {
     background-color: ${({ theme }) => theme.primary};
     color: ${({ theme }) => theme.text};
+  }
+`;
+
+export const MobileSubMenuAction = styled.div`
+  font-size: 1.5rem;
+  padding: 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  color: ${({ theme }) => theme.text};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.body};
   }
 `;
 

--- a/tournament-app/src/utils/index.ts
+++ b/tournament-app/src/utils/index.ts
@@ -87,3 +87,19 @@ export function compareRanks(player1: Player, player2: Player): number {
 
     return p1Max - p2Max;
 }
+
+export function getYearFromHash(hash: string): string | undefined {
+  const match = hash.match(/#\/(\d{4})/);
+  return match ? match[1] : undefined;
+}
+
+export function getYearDisplayString(hash: string): string {
+  const year = getYearFromHash(hash);
+  return year ? `GRumble ${year}` : "GRumble 2026";
+}
+
+export function getFirebasePrefix(): string {
+  const hash = window.location.hash;
+  const year = getYearFromHash(hash) || '2026';
+  return `grumble${year}`;
+}


### PR DESCRIPTION
Move GRumble 2025 to new "Year" dropdown, add "Coming Soon" default title page for GRumble 2026.

Update the access codes to use new migrated data schema, and only allows 2025 captains to access 2025 captain tools. (and future captains to only access future tournament tools).